### PR TITLE
Adds dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+venv/
+.pytest_cache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.8-slim-buster
+
+WORKDIR /app
+
+COPY requirements.txt requirements.txt
+
+RUN pip3 install -r requirements.txt
+
+COPY . .
+
+ENV FLASK_ENV=production
+ENV FLASK_APP=flasksrc
+
+EXPOSE 5000
+
+RUN flask init-db
+
+CMD [ "flask", "run", "--host", "0.0.0.0"]


### PR DESCRIPTION
This PR adds a Dockerfile to be used for toynet-flask. This will enable this project to be easier used within the docker-compose development setup that the frontend team uses as well as allowing the flask application to be deployed to ECS.

This was tested by building the image locally and testing each of the endpoints defined in the swagger docs.

Additionally, I noticed that we are not using a WSGI server for our production flask. We should look at using something like Gunicorn or [Waitress](https://flask.palletsprojects.com/en/1.1.x/tutorial/deploy/). The official flask documentation gives a quick summary of how to [deploy a flask app using waitress](https://flask.palletsprojects.com/en/1.1.x/tutorial/deploy/#run-with-a-production-server).